### PR TITLE
require latest underscore.string

### DIFF
--- a/package.js
+++ b/package.js
@@ -17,7 +17,7 @@ Package.onUse(function(api) {
 
   api.use([
     'iron:router@1.0.0',
-    'underscorestring:underscore.string@2.4.0'
+    'underscorestring:underscore.string@3.0.3'
   ]);
 
   api.addFiles('client/helpers.coffee', 'client');


### PR DESCRIPTION
fixes https://github.com/zimme/meteor-iron-router-active/issues/18 by exporting 's' 

see underscore.string changelog: https://github.com/epeli/underscore.string/blob/master/CHANGELOG.markdown#300